### PR TITLE
Filter ancestors by type for testname

### DIFF
--- a/nunit3-junit/nunit3-junit.xslt
+++ b/nunit3-junit/nunit3-junit.xslt
@@ -12,7 +12,7 @@
     <xsl:if test="test-case">
       <testsuite tests="{@testcasecount}" time="{@duration}" errors="{@testcasecount - @passed - @skipped - @failed}" failures="{@failed}" skipped="{@skipped}" timestamp="{@start-time}">
         <xsl:attribute name="name">
-          <xsl:for-each select="ancestor-or-self::test-suite/@name">
+          <xsl:for-each select="ancestor-or-self::test-suite[@type='TestSuite']/@name">
             <xsl:value-of select="concat(., '.')"/>
           </xsl:for-each>
         </xsl:attribute>


### PR DESCRIPTION
The testname has to much information when creating the junit report, e.g.:
```
<testsuite ... name="Some.csproj.Some.dll.Tests. ..."> ... </testsuite>
```

When I look at the nunit report there are two ancestors of the `test-case` element that cause this.

```
<?xml version="1.0" encoding="utf-8" standalone="no"?>
<test-run>
  ...
  <test-suite type="Project" id="1" name="Some.csproj" ... >  <-- Don't use this for testname
    <test-suite type="Assembly" id="3-1008" name="Some.dll" ... > <-- Don't use this for testname
      <environment ... />
      <settings>
        ...
      </settings>
      <properties>
        <property name="_PID" value="27208" />
        <property name="_APPDOMAIN" value="..." />
      </properties>
      <test-suite type="TestSuite" ... >
        ...
      </test-suite>
    </test-suite>
  </test-suite>
</test-run>
```

By filtering by type the testname is as expected.